### PR TITLE
Increased wall time of HUPANmapSLURM.pm to 16 hours

### DIFF
--- a/lib/HUPANmapSLURM.pm
+++ b/lib/HUPANmapSLURM.pm
@@ -207,6 +207,7 @@ foreach my $s (@sample){
 #	print JOB "\#SBATCH -p fat\n";               #stderr
 	print JOB "\#SBATCH -n $thread_num\n";             #thread number
 	print JOB "\#SBATCH --ntasks-per-node=$thread_num\n";
+	print JOB "\#SBATCH --time=16:00:00\n";
 	print JOB "$com\n";                              #commands
 	close JOB;
 	system("sbatch $job_file");                       #submit job


### PR DESCRIPTION
Time limit of 2 hours was causing jobs to timeout, tested three (large) samples and the longest time taken to complete the jobs was 12 hours.